### PR TITLE
Improve behavior when yielding

### DIFF
--- a/src/rt/atomic.rs
+++ b/src/rt/atomic.rs
@@ -1,0 +1,160 @@
+use rt::{self, thread, Synchronize};
+
+use std::sync::atomic::Ordering;
+
+#[derive(Debug, Default)]
+pub struct History {
+    stores: Vec<Store>,
+}
+
+#[derive(Debug)]
+struct Store {
+    /// Manages causality transfers between threads
+    sync: Synchronize,
+
+    /// Tracks when each thread first saw value
+    first_seen: FirstSeen,
+
+    /// True when the store was done with `SeqCst` ordering
+    seq_cst: bool,
+}
+
+#[derive(Debug)]
+struct FirstSeen(Vec<Option<usize>>);
+
+impl History {
+    pub fn init(&mut self, threads: &mut thread::Set) {
+        self.stores.push(Store {
+            sync: Synchronize::new(threads.max()),
+            first_seen: FirstSeen::new(threads),
+            seq_cst: false,
+        });
+    }
+
+    pub fn load(&mut self,
+                path: &mut rt::Path,
+                threads: &mut thread::Set,
+                order: Ordering) -> usize
+    {
+        // Pick a store that satisfies causality and specified ordering.
+        let index = self.pick_store(path, threads, order);
+        self.stores[index].first_seen.touch(threads);
+        self.stores[index].sync.sync_load(threads, order);
+        index
+    }
+
+    pub fn store(&mut self, threads: &mut thread::Set, order: Ordering) {
+        let mut store = Store {
+            sync: Synchronize::new(threads.max()),
+            first_seen: FirstSeen::new(threads),
+            seq_cst: is_seq_cst(order),
+        };
+
+        store.sync.sync_store(threads, order);
+        self.stores.push(store);
+    }
+
+    pub fn rmw<F, E>(&mut self,
+                     f: F,
+                     threads: &mut thread::Set,
+                     success: Ordering,
+                     failure: Ordering)
+        -> Result<usize, E>
+    where
+        F: FnOnce(usize) -> Result<(), E>
+    {
+        let index = self.stores.len() - 1;
+        self.stores[index].first_seen.touch(&threads);
+
+        if let Err(e) = f(index) {
+            self.stores[index].sync.sync_load(threads, failure);
+            return Err(e);
+        }
+
+        self.stores[index].sync.sync_load(threads, success);
+
+        let mut new = Store {
+            sync: Synchronize::new(threads.max()),
+            first_seen: FirstSeen::new(threads),
+            seq_cst: is_seq_cst(success),
+        };
+
+        new.sync.sync_store(threads, success);
+        self.stores.push(new);
+
+        Ok(index)
+    }
+
+    fn pick_store(&mut self,
+                  path: &mut rt::Path,
+                  threads: &mut thread::Set,
+                  order: Ordering)
+        -> usize
+    {
+        let mut first = true;
+
+        // TODO: This should factor in yielding...
+
+        path.branch_write({
+            self.stores.iter()
+                .enumerate()
+                .rev()
+                // Explore all stores that are not within the actor's causality
+                // as well as the latest one.
+                .take_while(|&(_, ref store)| {
+                    let mut in_causality = false;
+
+                    in_causality |= is_seq_cst(order) && store.seq_cst;
+                    in_causality |= store.first_seen.is_seen_by(&threads);
+
+                    let ret = !in_causality || first;
+                    first = false;
+                    ret
+                })
+                .map(|(i, _)| i)
+        })
+    }
+}
+
+impl FirstSeen {
+    fn new(threads: &mut thread::Set) -> FirstSeen {
+        let mut first_seen = FirstSeen(vec![]);
+        first_seen.touch(threads);
+
+        first_seen
+    }
+
+    fn touch(&mut self, threads: &thread::Set) {
+        let happens_before = &threads.active().causality;
+
+        if self.0.len() < happens_before.len() {
+            self.0.resize(happens_before.len(), None);
+        }
+
+        if self.0[threads.active_id().as_usize()].is_none() {
+            self.0[threads.active_id().as_usize()] = Some(threads.active_atomic_version());
+        }
+    }
+
+    fn is_seen_by(&self, threads: &thread::Set) -> bool {
+        for (thread_id, version) in threads.active().causality.versions() {
+            let seen = self.0.get(thread_id.as_usize())
+                .and_then(|maybe_version| *maybe_version)
+                .map(|v| v <= version)
+                .unwrap_or(false);
+
+            if seen {
+                return true;
+            }
+        }
+
+        false
+    }
+}
+
+fn is_seq_cst(order: Ordering) -> bool {
+    match order {
+        Ordering::SeqCst => true,
+        _ => false,
+    }
+}

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod arena;
+mod atomic;
 mod execution;
 mod fn_box;
 pub(crate) mod object;
@@ -58,6 +59,17 @@ where
     }
 
     ret
+}
+
+fn synchronize<F, R>(f: F) -> R
+where
+    F: FnOnce(&mut Execution) -> R
+{
+    execution(|execution| {
+        let ret = f(execution);
+        execution.threads.active_causality_inc();
+        ret
+    })
 }
 
 pub fn yield_now() {

--- a/src/rt/synchronize.rs
+++ b/src/rt/synchronize.rs
@@ -1,4 +1,4 @@
-use rt::{Execution, VersionVec};
+use rt::{thread, VersionVec};
 
 use std::sync::atomic::Ordering::{self, *};
 
@@ -17,43 +17,43 @@ impl Synchronize {
         }
     }
 
-    pub fn sync_read(&mut self, execution: &mut Execution, order: Ordering) {
+    pub fn sync_load(&mut self, threads: &mut thread::Set, order: Ordering) {
         match order {
             Relaxed | Release => {
                 // Nothing happens!
             }
             Acquire | AcqRel => {
-                self.sync_acq(execution);
+                self.sync_acq(threads);
             }
             SeqCst => {
-                self.sync_acq(execution);
-                execution.seq_cst();
+                self.sync_acq(threads);
+                threads.seq_cst();
             }
             order => unimplemented!("unimplemented ordering {:?}", order),
         }
     }
 
-    pub fn sync_write(&mut self, execution: &mut Execution, order: Ordering) {
+    pub fn sync_store(&mut self, threads: &mut thread::Set, order: Ordering) {
         match order {
             Relaxed | Acquire => {
                 // Nothing happens!
             }
             Release | AcqRel => {
-                self.sync_rel(execution);
+                self.sync_rel(threads);
             }
             SeqCst => {
-                self.sync_rel(execution);
-                execution.seq_cst();
+                self.sync_rel(threads);
+                threads.seq_cst();
             }
             order => unimplemented!("unimplemented ordering {:?}", order),
         }
     }
 
-    fn sync_acq(&mut self, execution: &mut Execution) {
-        execution.threads.active_mut().causality.join(&self.happens_before);
+    fn sync_acq(&mut self, threads: &mut thread::Set) {
+        threads.active_mut().causality.join(&self.happens_before);
     }
 
-    fn sync_rel(&mut self, execution: &mut Execution) {
-        self.happens_before.join(&execution.threads.active().causality);
+    fn sync_rel(&mut self, threads: &thread::Set) {
+        self.happens_before.join(&threads.active().causality);
     }
 }

--- a/src/rt/thread.rs
+++ b/src/rt/thread.rs
@@ -7,6 +7,8 @@ use std::ops;
 
 #[derive(Debug)]
 pub struct Thread {
+    pub id: Id,
+
     /// If the thread is runnable, blocked, or terminated.
     pub state: State,
 
@@ -24,6 +26,9 @@ pub struct Thread {
 
     /// Tracks a future's `Task::notify` flag
     pub notified: bool,
+
+    /// Version at which the thread last yielded
+    pub last_yield: Option<usize>,
 }
 
 #[derive(Debug)]
@@ -55,14 +60,16 @@ pub enum State {
 }
 
 impl Thread {
-    fn new(max_threads: usize) -> Thread {
+    fn new(id: Id, max_threads: usize) -> Thread {
         Thread {
+            id,
             state: State::Runnable,
             critical: false,
             operation: None,
             causality: VersionVec::new(max_threads),
             dpor_vv: VersionVec::new(max_threads),
             notified: false,
+            last_yield: None,
         }
     }
 
@@ -97,6 +104,7 @@ impl Thread {
 
     pub fn set_yield(&mut self) {
         self.state = State::Yield;
+        self.last_yield = Some(self.causality[self.id]);
     }
 
     pub fn is_terminated(&self) -> bool {
@@ -132,7 +140,8 @@ impl Set {
         let max_threads = self.threads.capacity();
 
         // Push the thread onto the stack
-        self.threads.push(Thread::new(max_threads));
+        self.threads.push(
+            Thread::new(Id::from_usize(id), max_threads));
 
         if self.active.is_none() {
             self.active = Some(id);

--- a/src/rt/thread.rs
+++ b/src/rt/thread.rs
@@ -8,7 +8,7 @@ use std::ops;
 #[derive(Debug)]
 pub struct Thread {
     /// If the thread is runnable, blocked, or terminated.
-    state: State,
+    pub state: State,
 
     /// True if the thread is in a critical section
     pub critical: bool,
@@ -36,13 +36,13 @@ pub struct Set {
     active: Option<usize>,
 }
 
-#[derive(Debug, Eq, PartialEq, Hash, Copy, Clone)]
+#[derive(Eq, PartialEq, Hash, Copy, Clone)]
 pub struct Id {
     id: usize,
     _p: PhantomData<::std::rc::Rc<()>>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum State {
     Runnable,
     Blocked,
@@ -149,7 +149,7 @@ impl Set {
     }
 
     pub fn set_active(&mut self, id: Option<Id>) {
-        self.active = id.map(Id::as_usize)
+        self.active = id.map(Id::as_usize);
     }
 
     pub fn active_mut(&mut self) -> &mut Thread {
@@ -273,4 +273,10 @@ impl fmt::Display for Id {
      fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
          self.id.fmt(fmt)
      }
+}
+
+impl fmt::Debug for Id {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "Id({})", self.id)
+    }
 }

--- a/src/sync/atomic/atomic.rs
+++ b/src/sync/atomic/atomic.rs
@@ -1,4 +1,4 @@
-use rt::{self, thread, Execution, Synchronize};
+use rt;
 use rt::object::{self, Object};
 
 use std::cell::RefCell;
@@ -7,27 +7,9 @@ use std::sync::atomic::Ordering;
 /// An atomic value
 #[derive(Debug)]
 pub struct Atomic<T> {
-    writes: RefCell<Vec<Write<T>>>,
     object: object::Id,
+    values: RefCell<Vec<T>>,
 }
-
-#[derive(Debug)]
-struct Write<T> {
-    /// The written value
-    value: T,
-
-    /// Manages causality transfers between threads
-    sync: Synchronize,
-
-    /// Tracks when each thread first saw value
-    first_seen: FirstSeen,
-
-    /// True when the write was done with `SeqCst` ordering
-    seq_cst: bool,
-}
-
-#[derive(Debug)]
-struct FirstSeen(Vec<Option<usize>>);
 
 impl<T> Atomic<T>
 where
@@ -35,40 +17,24 @@ where
 {
     pub fn new(value: T) -> Atomic<T> {
         rt::execution(|execution| {
-            let writes = vec![Write {
-                value,
-                sync: Synchronize::new(execution.max_threads),
-                first_seen: FirstSeen::new(execution),
-                seq_cst: false,
-            }];
+            let object = execution.objects.insert(Object::atomic());
+            object.atomic_init(execution);
 
             Atomic {
-                writes: RefCell::new(writes),
-                object: execution.objects.insert(Object::atomic()),
+                values: RefCell::new(vec![value]),
+                object,
             }
         })
     }
 
     pub fn load(&self, order: Ordering) -> T {
-        self.object.branch_load();
-        let mut writes = self.writes.borrow_mut();
-
-        synchronize(|execution| {
-            // Pick a write that satisfies causality and specified ordering.
-            let write = pick_write(&mut writes[..], execution, order);
-            write.first_seen.touch(&execution.threads);
-            write.sync.sync_read(execution, order);
-            write.value
-        })
+        let index = self.object.atomic_load(order);
+        self.values.borrow_mut()[index]
     }
 
-    pub fn store(&self, val: T, order: Ordering) {
-        self.object.branch_store();
-        let mut writes = self.writes.borrow_mut();
-
-        synchronize(|execution| {
-            do_write(val, &mut *writes, execution, order);
-        });
+    pub fn store(&self, value: T, order: Ordering) {
+        self.object.atomic_store(order);
+        self.values.borrow_mut().push(value);
     }
 
     /// Read-modify-write
@@ -78,6 +44,29 @@ where
     where
         F: FnOnce(T) -> T,
     {
+        self.try_rmw(|v| Ok::<_, ()>(f(v)), order, order).unwrap()
+    }
+
+    fn try_rmw<F, E>(&self, f: F, success: Ordering, failure: Ordering)
+        -> Result<T, E>
+    where
+        F: FnOnce(T) -> Result<T, E>,
+    {
+        let index = self.object.atomic_rmw(
+            |index| {
+                match f(self.values.borrow()[index]) {
+                    Ok(next) => {
+                        self.values.borrow_mut().push(next);
+                        Ok(())
+                    }
+                    Err(e) => Err(e),
+                }
+            },
+            success, failure)?;
+
+        Ok(self.values.borrow()[index])
+
+        /*
         self.object.branch_rmw();
         let mut writes = self.writes.borrow_mut();
 
@@ -92,6 +81,31 @@ where
             do_write(f(old), &mut *writes, execution, order);
             old
         })
+        */
+
+        // ===== compare xchange =====
+
+        /*
+        self.object.branch_rmw();
+        let mut writes = self.writes.borrow_mut();
+
+        synchronize(|execution| {
+            {
+                let write = writes.last_mut().unwrap();
+                write.first_seen.touch(&execution.threads);
+
+                if write.value != current {
+                    write.sync.sync_read(execution, failure);
+                    return Err(write.value);
+                }
+
+                write.sync.sync_read(execution, success);
+            }
+
+            do_write(new, &mut *writes, execution, success);
+            Ok(current)
+        })
+        */
     }
 
     pub fn swap(&self, val: T, order: Ordering) -> T {
@@ -121,128 +135,14 @@ where
         failure: Ordering
     ) -> Result<T, T>
     {
-        self.object.branch_rmw();
-        let mut writes = self.writes.borrow_mut();
-
-        synchronize(|execution| {
-            {
-                let write = writes.last_mut().unwrap();
-                write.first_seen.touch(&execution.threads);
-
-                if write.value != current {
-                    write.sync.sync_read(execution, failure);
-                    return Err(write.value);
+        self.try_rmw(
+            |actual| {
+                if actual == current {
+                    Ok(new)
+                } else {
+                    Err(actual)
                 }
-
-                write.sync.sync_read(execution, success);
-            }
-
-            do_write(new, &mut *writes, execution, success);
-            Ok(current)
-        })
-    }
-}
-
-fn pick_write<'a, T>(
-    writes: &'a mut [Write<T>],
-    execution: &mut Execution,
-    order: Ordering,
-) -> &'a mut Write<T>
-{
-    let mut first = true;
-    let threads = &mut execution.threads;
-
-    // TODO: This should factor in yielding...
-
-    let next = execution.path.branch_write({
-        writes.iter()
-            .enumerate()
-            .rev()
-            // Explore all writes that are not within the actor's causality as
-            // well as the latest one.
-            .take_while(|&(_, ref write)| {
-                let mut in_causality = false;
-
-                in_causality |= is_seq_cst(order) && write.seq_cst;
-                in_causality |= write.first_seen.is_seen_by(&threads);
-
-                let ret = !in_causality || first;
-                first = false;
-                ret
-            })
-            .map(|(i, _)| i)
-    });
-
-    &mut writes[next]
-}
-
-fn do_write<T>(
-    value: T,
-    writes: &mut Vec<Write<T>>,
-    execution: &mut Execution,
-    order: Ordering)
-{
-    let mut write = Write {
-        value,
-        sync: writes.last().unwrap().sync.clone(),
-        first_seen: FirstSeen::new(execution),
-        seq_cst: is_seq_cst(order),
-    };
-
-    write.sync.sync_write(execution, order);
-    writes.push(write);
-}
-
-fn synchronize<F, R>(f: F) -> R
-where
-    F: FnOnce(&mut Execution) -> R
-{
-    rt::execution(|execution| {
-        let ret = f(execution);
-        execution.threads.active_causality_inc();
-        ret
-    })
-}
-
-fn is_seq_cst(order: Ordering) -> bool {
-    match order {
-        Ordering::SeqCst => true,
-        _ => false,
-    }
-}
-
-impl FirstSeen {
-    fn new(execution: &mut Execution) -> FirstSeen {
-        let mut first_seen = FirstSeen(vec![]);
-        first_seen.touch(&execution.threads);
-
-        first_seen
-    }
-
-    fn touch(&mut self, threads: &thread::Set) {
-        let happens_before = &threads.active().causality;
-
-        if self.0.len() < happens_before.len() {
-            self.0.resize(happens_before.len(), None);
-        }
-
-        if self.0[threads.active_id().as_usize()].is_none() {
-            self.0[threads.active_id().as_usize()] = Some(threads.active_atomic_version());
-        }
-    }
-
-    fn is_seen_by(&self, threads: &thread::Set) -> bool {
-        for (thread_id, version) in threads.active().causality.versions() {
-            let seen = self.0.get(thread_id.as_usize())
-                .and_then(|maybe_version| *maybe_version)
-                .map(|v| v <= version)
-                .unwrap_or(false);
-
-            if seen {
-                return true;
-            }
-        }
-
-        false
+            },
+            success, failure)
     }
 }

--- a/src/sync/atomic/atomic.rs
+++ b/src/sync/atomic/atomic.rs
@@ -54,7 +54,8 @@ where
     {
         let index = self.object.atomic_rmw(
             |index| {
-                match f(self.values.borrow()[index]) {
+                let v = f(self.values.borrow()[index]);
+                match v {
                     Ok(next) => {
                         self.values.borrow_mut().push(next);
                         Ok(())

--- a/src/sync/atomic/atomic.rs
+++ b/src/sync/atomic/atomic.rs
@@ -66,47 +66,6 @@ where
             success, failure)?;
 
         Ok(self.values.borrow()[index])
-
-        /*
-        self.object.branch_rmw();
-        let mut writes = self.writes.borrow_mut();
-
-        synchronize(|execution| {
-            let old = {
-                let write = writes.last_mut().unwrap();
-                write.first_seen.touch(&execution.threads);
-                write.sync.sync_read(execution, order);
-                write.value
-            };
-
-            do_write(f(old), &mut *writes, execution, order);
-            old
-        })
-        */
-
-        // ===== compare xchange =====
-
-        /*
-        self.object.branch_rmw();
-        let mut writes = self.writes.borrow_mut();
-
-        synchronize(|execution| {
-            {
-                let write = writes.last_mut().unwrap();
-                write.first_seen.touch(&execution.threads);
-
-                if write.value != current {
-                    write.sync.sync_read(execution, failure);
-                    return Err(write.value);
-                }
-
-                write.sync.sync_read(execution, success);
-            }
-
-            do_write(new, &mut *writes, execution, success);
-            Ok(current)
-        })
-        */
     }
 
     pub fn swap(&self, val: T, order: Ordering) -> T {

--- a/src/sync/mutex.rs
+++ b/src/sync/mutex.rs
@@ -43,7 +43,7 @@ impl<T> Mutex<T> {
         self.object.branch_acquire(self.is_locked());
 
         rt::execution(|execution| {
-            execution.seq_cst();
+            execution.threads.seq_cst();
 
             let thread_id = execution.threads.active_id();
 
@@ -70,7 +70,7 @@ impl<T> Mutex<T> {
         self.lock.set(None);
 
         rt::execution(|execution| {
-            execution.seq_cst();
+            execution.threads.seq_cst();
 
             let thread_id = execution.threads.active_id();
 

--- a/tests/yield.rs
+++ b/tests/yield.rs
@@ -1,0 +1,29 @@
+extern crate loom;
+
+use loom::sync::atomic::AtomicUsize;
+use loom::thread;
+
+use std::sync::Arc;
+use std::sync::atomic::Ordering::Relaxed;
+
+#[test]
+fn yield_completes() {
+    loom::fuzz(|| {
+        let inc = Arc::new(AtomicUsize::new(0));
+
+        {
+            let inc = inc.clone();
+            thread::spawn(move || {
+                inc.store(1, Relaxed);
+            });
+        }
+
+        loop {
+            if 1 == inc.load(Relaxed) {
+                return;
+            }
+
+            loom::yield_now();
+        }
+    });
+}


### PR DESCRIPTION
Algorithms that depended on yielding could result in loom being unable
to make forwards progress. The workaround implemented in this patch is
not ideal in that it reduces the space searched with regards to atomics,
however atomics need to be revisted anyway.