### PR TITLE
Provide Arc implementation

### DIFF
--- a/src/sync/arc.rs
+++ b/src/sync/arc.rs
@@ -1,0 +1,54 @@
+use super::atomic::AtomicUsize;
+
+use std::ops;
+use std::rc::Rc;
+
+use std::sync::atomic::Ordering::*;
+
+/// TODO
+#[derive(Debug)]
+pub struct Arc<T> {
+    inner: Rc<Inner<T>>,
+}
+
+#[derive(Debug)]
+struct Inner<T> {
+    value: T,
+
+    /// Used to track causality
+    ref_cnt: AtomicUsize,
+}
+
+impl<T> Arc<T> {
+    /// TODO
+    pub fn new(value: T) -> Arc<T> {
+        Arc {
+            inner: Rc::new(Inner {
+                value,
+                ref_cnt: AtomicUsize::new(1),
+            })
+        }
+    }
+}
+
+impl<T> ops::Deref for Arc<T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &self.inner.value
+    }
+}
+
+impl<T> Clone for Arc<T> {
+    fn clone(&self) -> Arc<T> {
+        self.inner.ref_cnt.fetch_add(1, Relaxed);
+
+        Arc { inner: self.inner.clone() }
+    }
+}
+
+impl<T> Drop for Arc<T> {
+    fn drop(&mut self) {
+        self.inner.ref_cnt.fetch_sub(1, AcqRel);
+    }
+}

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -1,10 +1,12 @@
 //! Mock implementation of `std::atomic`.
 
+mod arc;
 mod causal;
 pub mod atomic;
 mod condvar;
 mod mutex;
 
+pub use self::arc::Arc;
 pub use self::causal::CausalCell;
 pub use self::condvar::{Condvar, WaitTimeoutResult};
 pub use self::mutex::{Mutex, MutexGuard};


### PR DESCRIPTION
This is needed when `CausalCell` instances are accessed on drop.