### PR TITLE
[WIP] Implement arena allocation for VersionVec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ checkpoint = ["serde", "serde_derive", "serde_json"]
 
 [dependencies]
 cfg-if = "0.1.6"
-# libc = "0.2.44"
+libc = "0.2.44"
 scoped-tls = "0.1.2"
 
 # Provides a generator based runtime

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ scoped-tls = "0.1.2"
 generator = { version = "0.6.10", optional = true }
 
 # Provides a runtime based on libfringe. Requires nightly.
-# fringe = { git = "https://github.com/carllerche/libfringe", branch = "track-nightly", optional = true }
+fringe = { git = "https://github.com/carllerche/libfringe", branch = "track-nightly", optional = true }
 
 # Optional futures support
 futures = { version = "0.1.25", optional = true }

--- a/src/futures/atomic_task.rs
+++ b/src/futures/atomic_task.rs
@@ -22,7 +22,7 @@ impl AtomicTask {
                 task: RefCell::new(None),
                 // TODO: Make a custom object?
                 object: execution.objects.insert(Object::condvar()),
-                sync: RefCell::new(Synchronize::new(execution.threads.max())),
+                sync: RefCell::new(Synchronize::new(&mut execution.arena, execution.threads.max())),
             }
         })
     }

--- a/src/rt/arena.rs
+++ b/src/rt/arena.rs
@@ -58,6 +58,7 @@ impl Arena {
     }
 
     pub fn clear(&mut self) {
+        println!("rc: {}", Rc::strong_count(&self.inner));
         assert!(1 == Rc::strong_count(&self.inner));
         self.inner.pos.set(0);
     }

--- a/src/rt/atomic.rs
+++ b/src/rt/atomic.rs
@@ -1,3 +1,4 @@
+use rt::arena::Arena;
 use rt::{self, thread, Synchronize, VersionVec};
 
 use std::sync::atomic::Ordering;
@@ -23,9 +24,9 @@ struct Store {
 struct FirstSeen(Vec<Option<usize>>);
 
 impl History {
-    pub fn init(&mut self, threads: &mut thread::Set) {
+    pub fn init(&mut self, arena: &mut Arena, threads: &mut thread::Set) {
         self.stores.push(Store {
-            sync: Synchronize::new(threads.max()),
+            sync: Synchronize::new(arena, threads.max()),
             first_seen: FirstSeen::new(threads),
             seq_cst: false,
         });
@@ -51,9 +52,9 @@ impl History {
         index
     }
 
-    pub fn store(&mut self, threads: &mut thread::Set, order: Ordering) {
+    pub fn store(&mut self, arena: &mut Arena, threads: &mut thread::Set, order: Ordering) {
         let mut store = Store {
-            sync: Synchronize::new(threads.max()),
+            sync: Synchronize::new(arena, threads.max()),
             first_seen: FirstSeen::new(threads),
             seq_cst: is_seq_cst(order),
         };

--- a/src/rt/object.rs
+++ b/src/rt/object.rs
@@ -178,7 +178,7 @@ impl Id {
 
     pub fn atomic_init(self, execution: &mut Execution) {
         execution.objects[self].atomic_mut()
-            .history.init(&mut execution.threads);
+            .history.init(&mut execution.arena, &mut execution.threads);
     }
 
     pub fn atomic_load(self, order: Ordering) -> usize {
@@ -205,7 +205,7 @@ impl Id {
             execution.objects[self]
                 .atomic_mut()
                 .history
-                .store(&mut execution.threads, order)
+                .store(&mut execution.arena, &mut execution.threads, order)
         })
     }
 

--- a/src/rt/synchronize.rs
+++ b/src/rt/synchronize.rs
@@ -1,3 +1,4 @@
+use rt::arena::Arena;
 use rt::{thread, VersionVec};
 
 use std::sync::atomic::Ordering::{self, *};
@@ -8,9 +9,8 @@ pub(crate) struct Synchronize {
 }
 
 impl Synchronize {
-    pub fn new(max_threads: usize) -> Self {
-        let happens_before =
-            VersionVec::new(max_threads);
+    pub fn new(arena: &mut Arena, max_threads: usize) -> Self {
+        let happens_before = VersionVec::new(arena, max_threads);
 
         Synchronize {
             happens_before,


### PR DESCRIPTION
I'm submitting this PR alongside my GSoC proposal (see
https://github.com/tokio-rs/gsoc/issues/2), providing two core changes:

* Building the `fringe` scheduler on nightly is possible again.
* `VersionVec` objects can now be allocated in an arena cleared after each iteration of
  the model checker. The implementation is based on the stub already present.

However, some caveats remain: It is debatable whether integrating the arena into the
`Execution` struct is the right way forward, since passing around a mutable reference to
the arena to allow allocation in various modules is certainly not ergonomic.

So far, performance on the workloads I've tested has been worse than expected, and plenty
other questions need to be discussed:

* Should other data structures be allocated in the arena?
* Should the allocation interface be changed?
* Does a drop-in solution for pointer bump arena allocation provide a performance benefit
  or some other advantage?
* Why did this implementation of arena allocation for some objects not provide the
  expected speedup?

Additionally, I was able to discover a resource leak in one of the `tokio-sync` tests
using this patch set: leaking objects mocked by `loom` can cause the arena to refuse
clearing, if `Slice`s allocated on behalf of the tested program are still live, so if
the tested program contains such a leak, the test crashes when `loom` tries to clear the
arena after the leaky iteration.

Here's the relevant function from the
[test](https://github.com/tokio-rs/tokio/blob/master/tokio-sync/tests/fuzz_list.rs):

```rust
// setup omitted

#[path = "../src/mpsc/list.rs"]
mod list;

#[test]
fn smoke() {
    loom::fuzz(|| {
        let (tx, mut rx) = list::channel();

        // lots of code omitted here...

        // This is necessary to avoid the leak, as no `Drop` impl for `list::Rx` is
        // provided, so the allocated blocks are never returned, causing a leak of objects
        // allocated by loom. On the other hand, providing a `Drop` impl breaks other
        // code.
        unsafe { rx.free_blocks(); }
    });
}
```

I'm unsure whether this is worth opening a tokio issue for, as the bug is largely
irrelevant in practise, and only amounts to leaking (tiny) amounts of memory in a test.