### PR TITLE
Flesh out the std::sync::Arc mock implementation

### DIFF
--- a/src/sync/arc.rs
+++ b/src/sync/arc.rs
@@ -29,6 +29,11 @@ impl<T> Arc<T> {
             })
         }
     }
+
+    /// Gets the number of strong (`Arc`) pointers to this value.
+    pub fn strong_count(this: &Self) -> usize {
+        this.inner.ref_cnt.load(SeqCst)
+    }
 }
 
 impl<T> ops::Deref for Arc<T> {

--- a/src/sync/arc.rs
+++ b/src/sync/arc.rs
@@ -69,3 +69,9 @@ impl<T: Default> Default for Arc<T> {
         Arc::new(Default::default())
     }
 }
+
+impl<T> From<T> for Arc<T> {
+    fn from(t: T) -> Self {
+        Arc::new(t)
+    }
+}

--- a/src/sync/arc.rs
+++ b/src/sync/arc.rs
@@ -63,3 +63,9 @@ impl<T> Drop for Arc<T> {
         self.inner.ref_cnt.fetch_sub(1, AcqRel);
     }
 }
+
+impl<T: Default> Default for Arc<T> {
+    fn default() -> Arc<T> {
+        Arc::new(Default::default())
+    }
+}

--- a/src/sync/arc.rs
+++ b/src/sync/arc.rs
@@ -5,7 +5,7 @@ use std::rc::Rc;
 
 use std::sync::atomic::Ordering::*;
 
-/// TODO
+/// Mock implementation of `std::sync::Arc`.
 #[derive(Debug)]
 pub struct Arc<T> {
     inner: Rc<Inner<T>>,
@@ -20,7 +20,7 @@ struct Inner<T> {
 }
 
 impl<T> Arc<T> {
-    /// TODO
+    /// Constructs a new `Arc<T>`.
     pub fn new(value: T) -> Arc<T> {
         Arc {
             inner: Rc::new(Inner {

--- a/src/sync/arc.rs
+++ b/src/sync/arc.rs
@@ -34,6 +34,12 @@ impl<T> Arc<T> {
     pub fn strong_count(this: &Self) -> usize {
         this.inner.ref_cnt.load(SeqCst)
     }
+
+    /// Returns `true` if the two `Arc`s point to the same value (not
+    /// just values that compare as equal).
+    pub fn ptr_eq(this: &Self, other: &Self) -> bool {
+        Rc::ptr_eq(&this.inner, &other.inner)
+    }
 }
 
 impl<T> ops::Deref for Arc<T> {


### PR DESCRIPTION
This PR adds the following APIs to `loom::sync::Arc<T>`:

- `Arc::ptr_eq`
- `Arc::strong_count`
- `Default`
- `From<T>`

It also adds some basic docs (the current docs just say "TODO").

Unresolved questions:

- Should we add support for weak refcounting?
- Should we add some tests for this Arc?
- How do we implement the methods that std uses fences for (`try_unwrap` etc.)?