### PR TITLE
Add `CausalCell` concurrent immut+mut access race detection

### DIFF
--- a/src/rt/execution.rs
+++ b/src/rt/execution.rs
@@ -74,7 +74,7 @@ impl Execution {
         new.causality.join(&active.causality);
         new.dpor_vv.join(&active.dpor_vv);
 
-        // Bump causality in order to ensure CausalCell accuratly detects
+        // Bump causality in order to ensure CausalCell accurately detects
         // incorrect access when first action.
         new.causality[thread_id] += 1;
         active.causality[active_id] += 1;

--- a/src/rt/vv.rs
+++ b/src/rt/vv.rs
@@ -45,6 +45,10 @@ impl VersionVec {
             self.versions[i] = cmp::max(self.versions[i], version);
         }
     }
+
+    pub fn copy_from(&mut self, other: &VersionVec) {
+        self.versions.copy_from_slice(&other.versions);
+    }
 }
 
 impl cmp::PartialOrd for VersionVec {

--- a/tests/causal_cell.rs
+++ b/tests/causal_cell.rs
@@ -10,47 +10,6 @@ use std::sync::atomic::Ordering::{Acquire, Release};
 use std::sync::Arc;
 
 #[test]
-fn thread_join_causality() {
-    #[derive(Clone)]
-    struct Data {
-        cell: Arc<CausalCell<usize>>,
-    }
-
-    impl Data {
-        fn new() -> Data {
-            Data {
-                cell: Arc::new(CausalCell::new(0)),
-            }
-        }
-
-        fn inc(&self) {
-            unsafe {
-                self.cell.with_mut(|v| {
-                    *v += 1;
-                });
-            }
-        }
-
-        fn get(&self) -> usize {
-            unsafe { self.cell.with(|v| *v) }
-        }
-    }
-
-    loom::model(|| {
-        let data = Data::new();
-
-        let th = {
-            let data = data.clone();
-
-            thread::spawn(move || data.inc())
-        };
-
-        th.join().unwrap();
-        assert_eq!(1, data.get());
-    });
-}
-
-#[test]
 fn atomic_causality_success() {
     struct Chan {
         data: CausalCell<usize>,
@@ -151,46 +110,210 @@ fn atomic_causality_fail() {
     });
 }
 
+#[derive(Clone)]
+struct Data(Arc<CausalCell<usize>>);
+
+impl Data {
+    fn new(v: usize) -> Self {
+        Data(Arc::new(CausalCell::new(v)))
+    }
+
+    fn get(&self) -> usize {
+        self.0.with(|v| unsafe { *v })
+    }
+
+    fn inc(&self) -> usize {
+        self.0.with_mut(|v| unsafe {
+            *v += 1;
+            *v
+        })
+    }
+}
+
 #[test]
 #[should_panic]
-fn causal_cell_race_1() {
+fn causal_cell_race_mut_mut_1() {
     loom::model(|| {
-        let x = Arc::new(CausalCell::new(1_u32));
-        let y = Arc::clone(&x);
+        let x = Data::new(1);
+        let y = x.clone();
 
-        let th1 = thread::spawn(move || {
-            x.with_mut(|v| unsafe { *v += 1 });
-        });
-
-        y.with_mut(|v| unsafe { *v += 10 });
+        let th1 = thread::spawn(move || x.inc());
+        y.inc();
 
         th1.join().unwrap();
 
-        let v = y.with_mut(|v| unsafe { *v });
-        assert_eq!(12, v);
+        assert_eq!(4, y.inc());
     });
 }
 
 #[test]
 #[should_panic]
-fn causal_cell_race_2() {
+fn causal_cell_race_mut_mut_2() {
     loom::model(|| {
-        let x = Arc::new(CausalCell::new(1_u32));
-        let y = Arc::clone(&x);
-        let z = Arc::clone(&x);
+        let x = Data::new(1);
+        let y = x.clone();
+        let z = x.clone();
 
-        let th1 = thread::spawn(move || {
-            x.with_mut(|v| unsafe { *v += 1 });
-        });
+        let th1 = thread::spawn(move || x.inc());
+        let th2 = thread::spawn(move || y.inc());
 
+        th1.join().unwrap();
+        th2.join().unwrap();
+
+        assert_eq!(4, z.inc());
+    });
+}
+
+#[test]
+#[should_panic]
+fn causal_cell_race_mut_immut_1() {
+    loom::model(|| {
+        let x = Data::new(1);
+        let y = x.clone();
+
+        let th1 = thread::spawn(move || assert_eq!(2, x.inc()));
+        y.get();
+
+        th1.join().unwrap();
+
+        assert_eq!(3, y.inc());
+    });
+}
+
+#[test]
+#[should_panic]
+fn causal_cell_race_mut_immut_2() {
+    loom::model(|| {
+        let x = Data::new(1);
+        let y = x.clone();
+
+        let th1 = thread::spawn(move || x.get());
+        assert_eq!(2, y.inc());
+
+        th1.join().unwrap();
+
+        assert_eq!(3, y.inc());
+    });
+}
+
+#[test]
+#[should_panic]
+fn causal_cell_race_mut_immut_3() {
+    loom::model(|| {
+        let x = Data::new(1);
+        let y = x.clone();
+        let z = x.clone();
+
+        let th1 = thread::spawn(move || assert_eq!(2, x.inc()));
+        let th2 = thread::spawn(move || y.get());
+
+        th1.join().unwrap();
+        th2.join().unwrap();
+
+        assert_eq!(3, z.inc());
+    });
+}
+
+#[test]
+#[should_panic]
+fn causal_cell_race_mut_immut_4() {
+    loom::model(|| {
+        let x = Data::new(1);
+        let y = x.clone();
+        let z = x.clone();
+
+        let th1 = thread::spawn(move || x.get());
+        let th2 = thread::spawn(move || assert_eq!(2, y.inc()));
+
+        th1.join().unwrap();
+        th2.join().unwrap();
+
+        assert_eq!(3, z.inc());
+    });
+}
+
+#[test]
+#[should_panic]
+fn causal_cell_race_mut_immut_5() {
+    loom::model(|| {
+        let x = Data::new(1);
+        let y = x.clone();
+        let z = x.clone();
+
+        let th1 = thread::spawn(move || x.get());
         let th2 = thread::spawn(move || {
-            y.with_mut(|v| unsafe { *v += 10 });
+            assert_eq!(1, y.get());
+            assert_eq!(2, y.inc());
         });
 
         th1.join().unwrap();
         th2.join().unwrap();
 
-        let v = z.with_mut(|v| unsafe { *v });
-        assert_eq!(12, v);
+        assert_eq!(3, z.inc());
+    });
+}
+
+#[test]
+fn causal_cell_ok_1() {
+    loom::model(|| {
+        let x = Data::new(1);
+
+        assert_eq!(2, x.inc());
+
+        let th1 = thread::spawn(move || {
+            assert_eq!(3, x.inc());
+            x
+        });
+
+        let x = th1.join().unwrap();
+
+        assert_eq!(4, x.inc());
+    });
+}
+
+#[test]
+fn causal_cell_ok_2() {
+    loom::model(|| {
+        let x = Data::new(1);
+
+        assert_eq!(1, x.get());
+        assert_eq!(2, x.inc());
+
+        let th1 = thread::spawn(move || {
+            assert_eq!(2, x.get());
+            assert_eq!(3, x.inc());
+            x
+        });
+
+        let x = th1.join().unwrap();
+
+        assert_eq!(3, x.get());
+        assert_eq!(4, x.inc());
+    });
+}
+
+#[test]
+fn causal_cell_ok_3() {
+    loom::model(|| {
+        let x = Data::new(1);
+        let y = x.clone();
+
+        let th1 = thread::spawn(move || {
+            assert_eq!(1, x.get());
+
+            let z = x.clone();
+            let th2 = thread::spawn(move || {
+                assert_eq!(1, z.get());
+            });
+
+            assert_eq!(1, x.get());
+            th2.join().unwrap();
+        });
+
+        assert_eq!(1, y.get());
+
+        th1.join().unwrap();
+
+        assert_eq!(2, y.inc());
     });
 }


### PR DESCRIPTION
+ `CausalCell` now also keeps track of closure of immutable access times.

+ Mutable access now panics on concurrent immutable access(es).

+ Immutable access now correctly panics on concurrent mutable access.

+ Add `VersionVector::copy_from`.