### PR TITLE
Implement Default for atomics

### DIFF
--- a/src/sync/atomic/atomic.rs
+++ b/src/sync/atomic/atomic.rs
@@ -124,3 +124,12 @@ where
         )
     }
 }
+
+impl<T> Default for Atomic<T>
+where
+    T: Default + Copy + PartialEq,
+{
+    fn default() -> Atomic<T> {
+        Atomic::new(T::default())
+    }
+}

--- a/src/sync/atomic/bool.rs
+++ b/src/sync/atomic/bool.rs
@@ -3,7 +3,7 @@ use super::Atomic;
 use std::sync::atomic::Ordering;
 
 /// Mock implementation of `std::sync::atomic::AtomicBool`.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct AtomicBool(Atomic<bool>);
 
 impl AtomicBool {

--- a/src/sync/atomic/int.rs
+++ b/src/sync/atomic/int.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::Ordering;
 macro_rules! atomic_int {
     ($name: ident, $atomic_type: ty) => {
         /// Mock implementation of `std::sync::atomic::$name`.
-        #[derive(Debug)]
+        #[derive(Debug, Default)]
         pub struct $name(Atomic<$atomic_type>);
 
         impl $name {

--- a/src/sync/atomic/ptr.rs
+++ b/src/sync/atomic/ptr.rs
@@ -48,3 +48,9 @@ impl<T> AtomicPtr<T> {
         self.0.compare_exchange(current, new, success, failure)
     }
 }
+
+impl<T> Default for AtomicPtr<T> {
+    fn default() -> AtomicPtr<T> {
+        AtomicPtr::new(std::ptr::null_mut())
+    }
+}


### PR DESCRIPTION
Hey! Just tried using `loom`, and hit the issue of loom's atomics not being exactly std's atomics -- here is a PR to try and reduce this by implementing `Default` for atomics.