### PR TITLE
Add mock thread locals

### DIFF
--- a/src/rt/thread.rs
+++ b/src/rt/thread.rs
@@ -301,10 +301,7 @@ impl Set {
         (&mut active[0], iter)
     }
 
-    pub(crate) fn local<'a, T: 'static>(
-        &'a mut self,
-        key: &'static crate::thread::LocalKey<T>,
-    ) -> &T {
+    pub(crate) fn local<T: 'static>(&mut self, key: &'static crate::thread::LocalKey<T>) -> &T {
         self.active_mut()
             .locals
             .entry(LocalKeyId::new(key))

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -1,8 +1,8 @@
 //! Mock implementation of `std::thread`.
 
 use crate::rt;
+pub use crate::rt::thread::AccessError;
 pub use crate::rt::yield_now;
-pub use std::thread::AccessError;
 
 use std::cell::RefCell;
 use std::fmt;
@@ -69,22 +69,8 @@ impl<T: 'static> LocalKey<T> {
     where
         F: FnOnce(&T) -> R,
     {
-        unsafe fn transmute_lt<'a, 'b, T>(t: &'a T) -> &'b T {
-            std::mem::transmute::<&'a T, &'b T>(t)
-        }
-
-        let value = rt::execution(|execution| {
-            let local = execution.threads.local(self);
-            // This is, sadly, necessary to allow nested `with` blocks to access
-            // different thread locals. The borrow on the thread-local needs to
-            // escape the lifetime of the borrow on `execution`, since
-            // `rt::execution` mutably borrows a RefCell, and borrowing it twice will
-            // cause a panic. This should be safe, as we know the function being
-            // passed the thread local will not outlive the thread on which
-            // it's executing, by construction --- it's just kind of unfortunate.
-            unsafe { transmute_lt(local) }
-        });
-        f(value)
+        self.try_with(f)
+            .expect("cannot access a (mock) TLS value during or after it is destroyed")
     }
 
     /// Mock implementation of `std::thread::LocalKey::try_with`.
@@ -92,8 +78,22 @@ impl<T: 'static> LocalKey<T> {
     where
         F: FnOnce(&T) -> R,
     {
-        // TODO(eliza): handle destructors
-        Ok(self.with(f))
+        unsafe fn transmute_lt<'a, 'b, T>(t: &'a T) -> &'b T {
+            std::mem::transmute::<&'a T, &'b T>(t)
+        }
+
+        let value = rt::execution(|execution| {
+            let local = execution.threads.local(self)?;
+            // This is, sadly, necessary to allow nested `with` blocks to access
+            // different thread locals. The borrow on the thread-local needs to
+            // escape the lifetime of the borrow on `execution`, since
+            // `rt::execution` mutably borrows a RefCell, and borrowing it twice will
+            // cause a panic. This should be safe, as we know the function being
+            // passed the thread local will not outlive the thread on which
+            // it's executing, by construction --- it's just kind of unfortunate.
+            Ok(unsafe { transmute_lt(local) })
+        })?;
+        Ok(f(value))
     }
 }
 

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -2,15 +2,30 @@
 
 use crate::rt;
 pub use crate::rt::yield_now;
+pub use std::thread::AccessError;
 
 use std::cell::RefCell;
 use std::fmt;
+use std::marker::PhantomData;
 use std::rc::Rc;
 
 /// Mock implementation of `std::thread::JoinHandle`.
 pub struct JoinHandle<T> {
     result: Rc<RefCell<Option<std::thread::Result<T>>>>,
     notify: rt::Notify,
+}
+
+/// Mock implementation of `std::thread::LocalKey`.
+pub struct LocalKey<T> {
+    // Sadly, these fields have to be public, since function pointers in const
+    // fns are unstable. When fn pointer arguments to const fns stabilize, these
+    // should be made private and replaced with a `const fn new`.
+    //
+    // User code should not rely on the existence of these fields.
+    #[doc(hidden)]
+    pub init: fn() -> T,
+    #[doc(hidden)]
+    pub _p: PhantomData<fn(T)>,
 }
 
 /// Mock implementation of `std::thread::spawn`.
@@ -45,5 +60,33 @@ impl<T> JoinHandle<T> {
 impl<T: fmt::Debug> fmt::Debug for JoinHandle<T> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("JoinHandle").finish()
+    }
+}
+
+impl<T: 'static> LocalKey<T> {
+    /// Mock implementation of `std::thread::LocalKey::with`.
+    pub fn with<F, R>(&'static self, f: F) -> R
+    where
+        F: FnOnce(&T) -> R,
+    {
+        rt::execution(|execution| {
+            let value = execution.threads.local(self);
+            f(value)
+        })
+    }
+
+    /// Mock implementation of `std::thread::LocalKey::try_with`.
+    pub fn try_with<F, R>(&'static self, f: F) -> Result<R, AccessError>
+    where
+        F: FnOnce(&T) -> R,
+    {
+        // TODO(eliza): handle destructors
+        Ok(self.with(f))
+    }
+}
+
+impl<T: 'static> fmt::Debug for LocalKey<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.pad("LocalKey { .. }")
     }
 }

--- a/tests/thread_local.rs
+++ b/tests/thread_local.rs
@@ -1,6 +1,7 @@
 #![deny(warnings, rust_2018_idioms)]
 use loom::thread;
 use std::cell::RefCell;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 #[test]
 fn thread_local() {
@@ -44,4 +45,45 @@ fn nested_with() {
     loom::model(|| {
         LOCAL1.with(|local1| *local1.borrow_mut() = LOCAL2.with(|local2| local2.borrow().clone()));
     });
+}
+
+#[test]
+fn drop() {
+    static DROPS: AtomicUsize = AtomicUsize::new(0);
+    #[allow(dead_code)]
+    struct CountDrops(&'static AtomicUsize);
+
+    impl Drop for CountDrops {
+        fn drop(&mut self) {
+            self.0.fetch_add(1, Ordering::Release);
+        }
+    }
+
+    loom::thread_local! {
+        static DROPPED_LOCAL: CountDrops = CountDrops(&DROPS);
+    }
+
+    loom::model(|| {
+        assert_eq!(DROPS.load(Ordering::Acquire), 0);
+
+        thread::spawn(|| assert_eq!(DROPS.load(Ordering::Acquire), 0))
+            .join()
+            .unwrap();
+
+        // When the first spawned thread completed, its copy of the thread local
+        // should have been dropped.
+        assert_eq!(DROPS.load(Ordering::Acquire), 1);
+
+        thread::spawn(|| assert_eq!(DROPS.load(Ordering::Acquire), 1))
+            .join()
+            .unwrap();
+
+        // When the second spawned thread completed, its copy of the thread local
+        // should have been dropped as well.
+        assert_eq!(DROPS.load(Ordering::Acquire), 2);
+    });
+
+    // Finally, when the model's "main thread" completes, its copy of the local
+    // should also be dropped.
+    assert_eq!(DROPS.load(Ordering::Acquire), 3);
 }

--- a/tests/thread_local.rs
+++ b/tests/thread_local.rs
@@ -7,48 +7,41 @@ fn thread_local() {
     loom::thread_local! {
         static THREAD_LOCAL: RefCell<usize> = RefCell::new(1);
     }
+
+    fn do_test(n: usize) {
+        THREAD_LOCAL.with(|local| {
+            assert_eq!(*local.borrow(), 1);
+        });
+        THREAD_LOCAL.with(|local| {
+            assert_eq!(*local.borrow(), 1);
+            *local.borrow_mut() = n;
+            assert_eq!(*local.borrow(), n);
+        });
+        THREAD_LOCAL.with(|local| {
+            assert_eq!(*local.borrow(), n);
+        });
+    }
+
     loom::model(|| {
-        let t1 = thread::spawn(|| {
-            THREAD_LOCAL.with(|local| {
-                assert_eq!(*local.borrow(), 1);
-            });
-            THREAD_LOCAL.with(|local| {
-                assert_eq!(*local.borrow(), 1);
-                *local.borrow_mut() = 2;
-                assert_eq!(*local.borrow(), 2);
-            });
-            THREAD_LOCAL.with(|local| {
-                assert_eq!(*local.borrow(), 2);
-            });
-        });
+        let t1 = thread::spawn(|| do_test(2));
 
-        let t2 = thread::spawn(|| {
-            THREAD_LOCAL.with(|local| {
-                assert_eq!(*local.borrow(), 1);
-            });
-            THREAD_LOCAL.with(|local| {
-                assert_eq!(*local.borrow(), 1);
-                *local.borrow_mut() = 3;
-                assert_eq!(*local.borrow(), 3);
-            });
-            THREAD_LOCAL.with(|local| {
-                assert_eq!(*local.borrow(), 3);
-            });
-        });
+        let t2 = thread::spawn(|| do_test(3));
 
-        THREAD_LOCAL.with(|local| {
-            assert_eq!(*local.borrow(), 1);
-        });
-        THREAD_LOCAL.with(|local| {
-            assert_eq!(*local.borrow(), 1);
-            *local.borrow_mut() = 4;
-            assert_eq!(*local.borrow(), 4);
-        });
-        THREAD_LOCAL.with(|local| {
-            assert_eq!(*local.borrow(), 4);
-        });
+        do_test(4);
 
         t1.join().unwrap();
         t2.join().unwrap();
+    });
+}
+
+#[test]
+fn nested_with() {
+    loom::thread_local! {
+        static LOCAL1: RefCell<usize> = RefCell::new(1);
+        static LOCAL2: RefCell<usize> = RefCell::new(2);
+    }
+
+    loom::model(|| {
+        LOCAL1.with(|local1| *local1.borrow_mut() = LOCAL2.with(|local2| local2.borrow().clone()));
     });
 }

--- a/tests/thread_local.rs
+++ b/tests/thread_local.rs
@@ -1,0 +1,54 @@
+#![deny(warnings, rust_2018_idioms)]
+use loom::thread;
+use std::cell::RefCell;
+
+#[test]
+fn thread_local() {
+    loom::thread_local! {
+        static THREAD_LOCAL: RefCell<usize> = RefCell::new(1);
+    }
+    loom::model(|| {
+        let t1 = thread::spawn(|| {
+            THREAD_LOCAL.with(|local| {
+                assert_eq!(*local.borrow(), 1);
+            });
+            THREAD_LOCAL.with(|local| {
+                assert_eq!(*local.borrow(), 1);
+                *local.borrow_mut() = 2;
+                assert_eq!(*local.borrow(), 2);
+            });
+            THREAD_LOCAL.with(|local| {
+                assert_eq!(*local.borrow(), 2);
+            });
+        });
+
+        let t2 = thread::spawn(|| {
+            THREAD_LOCAL.with(|local| {
+                assert_eq!(*local.borrow(), 1);
+            });
+            THREAD_LOCAL.with(|local| {
+                assert_eq!(*local.borrow(), 1);
+                *local.borrow_mut() = 3;
+                assert_eq!(*local.borrow(), 3);
+            });
+            THREAD_LOCAL.with(|local| {
+                assert_eq!(*local.borrow(), 3);
+            });
+        });
+
+        THREAD_LOCAL.with(|local| {
+            assert_eq!(*local.borrow(), 1);
+        });
+        THREAD_LOCAL.with(|local| {
+            assert_eq!(*local.borrow(), 1);
+            *local.borrow_mut() = 4;
+            assert_eq!(*local.borrow(), 4);
+        });
+        THREAD_LOCAL.with(|local| {
+            assert_eq!(*local.borrow(), 4);
+        });
+
+        t1.join().unwrap();
+        t2.join().unwrap();
+    });
+}


### PR DESCRIPTION
When running a test that uses `loom`'s mock threads, all the mock
threads in the test are actually run on the same OS thread. This means
that code which uses thread local storage will not behave the same
inside of a `loom` test — every `loom` "thread" will actually see the
same version of the thread-local.

This branch adds a mock implementation of the Rust standard library's
`std::thread::LocalKey` type to `loom::thread`, and a mock version of
the `thread_local!` macro that expands to a mock `loom` `LocalKey`.

This is implemented by adding a hash map of `LocalKey`static addresses
to  `Box<dyn Any>`s in the `loom::rt::thread::Thread` type, and having
the mock `LocalKey` type access the current thread from the runtime, and
use its address to index the current thread's map. The boxed `Any` value
is then downcast to the expected type, which should always succeed since
the thread-local is constructed with an initializer returning that type.

Unfortunately, it was necessary to make the mock `LocalKey`'s fields
`#[doc(hidden)] pub`, since we cannot currently write a `const fn`
constructor for it, as `const fn`s with function pointer arguments
aren't currently stable. This can be resolved when function pointer args
to `const fn`s stabilize.

I've also added a test that each `loom` mock thread accesses its own
version of the mock thread local.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>