### PR TITLE
Provide an API to defer causality checks

### DIFF
--- a/src/rt/atomic.rs
+++ b/src/rt/atomic.rs
@@ -115,7 +115,7 @@ pub(crate) fn fence(order: Ordering) {
         "only Acquire fences are currently supported"
     );
 
-    rt::execution(|execution| {
+    rt::synchronize(|execution| {
         // Find all stores for all atomic objects and, if they have been read by
         // the current thread, establish an acquire synchronization.
         for state in execution.objects.atomics_mut() {
@@ -128,8 +128,6 @@ pub(crate) fn fence(order: Ordering) {
                 store.sync.sync_load(&mut execution.threads, order);
             }
         }
-
-        execution.threads.active_causality_inc();
     });
 }
 

--- a/src/sync/causal/cell.rs
+++ b/src/sync/causal/cell.rs
@@ -140,10 +140,7 @@ impl<T> CausalCell<T> {
                     "Causality violation: \
                      Concurrent mutable access and immutable access(es): \
                      cell.with: v={:?}; mut v: {:?}; thread[{}]={:?}",
-                    immut_access_version,
-                    mut_access_version,
-                    thread_id,
-                    thread_causality
+                    immut_access_version, mut_access_version, thread_id, thread_causality
                 );
 
                 return Err(msg);
@@ -184,10 +181,7 @@ impl<T> CausalCell<T> {
                     "Causality violation: \
                      Concurrent mutable accesses: \
                      cell.with_mut: v={:?}; mut v={:?}; thread[{}]={:?}",
-                    immut_access_version,
-                    mut_access_version,
-                    thread_id,
-                    thread_causality,
+                    immut_access_version, mut_access_version, thread_id, thread_causality,
                 );
 
                 return Err(msg);
@@ -201,10 +195,7 @@ impl<T> CausalCell<T> {
                     "Causality violation: \
                      Concurrent mutable access and immutable access(es): \
                      cell.with_mut: v={:?}; mut v={:?}; thread[{}]={:?}",
-                    immut_access_version,
-                    mut_access_version,
-                    thread_id,
-                    thread_causality,
+                    immut_access_version, mut_access_version, thread_id, thread_causality,
                 );
 
                 return Err(msg);

--- a/src/sync/causal/cell.rs
+++ b/src/sync/causal/cell.rs
@@ -135,7 +135,9 @@ impl<T> CausalCell<T> {
             // Check that there is no concurrent mutable access, i.e., the last
             // mutable access must happen-before this immutable access.
 
-            if *mut_access_version > *thread_causality {
+            // Negating the comparison as version vectors are not totally
+            // ordered.
+            if !(*mut_access_version <= *thread_causality) {
                 let msg = format!(
                     "Causality violation: \
                      Concurrent mutable access and immutable access(es): \
@@ -176,7 +178,9 @@ impl<T> CausalCell<T> {
             // Check that there is no concurrent mutable access, i.e., the last
             // mutable access must happen-before this mutable access.
 
-            if *mut_access_version > *thread_causality {
+            // Negating the comparison as version vectors are not totally
+            // ordered.
+            if !(*mut_access_version <= *thread_causality) {
                 let msg = format!(
                     "Causality violation: \
                      Concurrent mutable accesses: \
@@ -189,8 +193,10 @@ impl<T> CausalCell<T> {
 
             // Check that there are no concurrent immutable accesss, i.e., every
             // immutable access must happen-before this mutable access.
-
-            if *immut_access_version > *thread_causality {
+            //
+            // Negating the comparison as version vectors are not totally
+            // ordered.
+            if !(*immut_access_version <= *thread_causality) {
                 let msg = format!(
                     "Causality violation: \
                      Concurrent mutable access and immutable access(es): \

--- a/src/sync/causal/cell.rs
+++ b/src/sync/causal/cell.rs
@@ -15,6 +15,11 @@ pub struct CausalCell<T> {
     mut_access_version: RefCell<VersionVec>,
 }
 
+/// Deferred causal cell check
+#[derive(Debug)]
+#[must_use]
+pub struct CausalCheck(Result<(), String>);
+
 impl<T> CausalCell<T> {
     /// Construct a new instance of `CausalCell` which will wrap the specified
     /// value.
@@ -44,6 +49,23 @@ impl<T> CausalCell<T> {
         })
     }
 
+    /// Get an immutable pointer to the wrapped value, deferring the causality
+    /// check.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if the access is not valid under the Rust memory
+    /// model.
+    pub fn with_deferred<F, R>(&self, f: F) -> (R, CausalCheck)
+    where
+        F: FnOnce(*const T) -> R,
+    {
+        rt::critical(|| {
+            let res = self.check2();
+            (self.with_unchecked(f), CausalCheck(res))
+        })
+    }
+
     /// Get a mutable pointer to the wrapped value.
     ///
     /// # Panics
@@ -57,6 +79,22 @@ impl<T> CausalCell<T> {
         rt::critical(|| {
             self.check_mut();
             self.with_mut_unchecked(f)
+        })
+    }
+
+    /// Get a mutable pointer to the wrapped value.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if the access is not valid under the Rust memory
+    /// model.
+    pub fn with_deferred_mut<F, R>(&self, f: F) -> (R, CausalCheck)
+    where
+        F: FnOnce(*mut T) -> R,
+    {
+        rt::critical(|| {
+            let res = self.check2_mut();
+            (self.with_mut_unchecked(f), CausalCheck(res))
         })
     }
 
@@ -83,6 +121,10 @@ impl<T> CausalCell<T> {
     /// access with this immutable access, while allowing many concurrent
     /// immutable accesses.
     pub fn check(&self) {
+        self.check2().unwrap()
+    }
+
+    fn check2_mut(&self) -> Result<(), String> {
         rt::execution(|execution| {
             let mut immut_access_version = self.immut_access_version.borrow_mut();
             let mut_access_version = self.mut_access_version.borrow();
@@ -93,16 +135,19 @@ impl<T> CausalCell<T> {
             // Check that there is no concurrent mutable access, i.e., the last
             // mutable access must happen-before this immutable access.
 
-            assert!(
-                *mut_access_version <= *thread_causality,
-                "Causality violation: \
-                 Concurrent mutable access and immutable access(es): \
-                 cell.with: v={:?}; mut v: {:?}; thread[{}]={:?}",
-                immut_access_version,
-                mut_access_version,
-                thread_id,
-                thread_causality,
-            );
+            if *mut_access_version > *thread_causality {
+                let msg = format!(
+                    "Causality violation: \
+                     Concurrent mutable access and immutable access(es): \
+                     cell.with: v={:?}; mut v: {:?}; thread[{}]={:?}",
+                    immut_access_version,
+                    mut_access_version,
+                    thread_id,
+                    thread_causality
+                );
+
+                return Err(msg);
+            }
 
             // Join in the vector clock time of this immutable access.
             //
@@ -110,7 +155,8 @@ impl<T> CausalCell<T> {
             // all concurrent immutable access versions.
 
             immut_access_version.join(thread_causality);
-        });
+            Ok(())
+        })
     }
 
     /// Check that the current thread can make a mutable access without violating
@@ -119,6 +165,10 @@ impl<T> CausalCell<T> {
     /// Specifically, this function checks that there is no concurrent mutable
     /// access and no concurrent immutable access(es) with this mutable access.
     pub fn check_mut(&self) {
+        self.check2_mut().unwrap();
+    }
+
+    fn check2(&self) -> Result<(), String> {
         rt::execution(|execution| {
             let immut_access_version = self.immut_access_version.borrow();
             let mut mut_access_version = self.mut_access_version.borrow_mut();
@@ -129,30 +179,36 @@ impl<T> CausalCell<T> {
             // Check that there is no concurrent mutable access, i.e., the last
             // mutable access must happen-before this mutable access.
 
-            assert!(
-                *mut_access_version <= *thread_causality,
-                "Causality violation: \
-                 Concurrent mutable accesses: \
-                 cell.with_mut: v={:?}; mut v={:?}; thread[{}]={:?}",
-                immut_access_version,
-                mut_access_version,
-                thread_id,
-                thread_causality,
-            );
+            if *mut_access_version > *thread_causality {
+                let msg = format!(
+                    "Causality violation: \
+                     Concurrent mutable accesses: \
+                     cell.with_mut: v={:?}; mut v={:?}; thread[{}]={:?}",
+                    immut_access_version,
+                    mut_access_version,
+                    thread_id,
+                    thread_causality,
+                );
+
+                return Err(msg);
+            }
 
             // Check that there are no concurrent immutable accesss, i.e., every
             // immutable access must happen-before this mutable access.
 
-            assert!(
-                *immut_access_version <= *thread_causality,
-                "Causality violation: \
-                 Concurrent mutable access and immutable access(es): \
-                 cell.with_mut: v={:?}; mut v={:?}; thread[{}]={:?}",
-                immut_access_version,
-                mut_access_version,
-                thread_id,
-                thread_causality,
-            );
+            if *immut_access_version > *thread_causality {
+                let msg = format!(
+                    "Causality violation: \
+                     Concurrent mutable access and immutable access(es): \
+                     cell.with_mut: v={:?}; mut v={:?}; thread[{}]={:?}",
+                    immut_access_version,
+                    mut_access_version,
+                    thread_id,
+                    thread_causality,
+                );
+
+                return Err(msg);
+            }
 
             // Record the vector clock time of this mutable access.
             //
@@ -161,6 +217,27 @@ impl<T> CausalCell<T> {
             // `mut_access_version.join(thread_causality) == thread_causality`.
 
             mut_access_version.copy_from(thread_causality);
-        });
+            Ok(())
+        })
+    }
+}
+
+impl CausalCheck {
+    /// Panic if the CausaalCell access was invalid.
+    pub fn check(self) {
+        self.0.unwrap();
+    }
+
+    /// Merge this check with another check
+    pub fn join(&mut self, other: CausalCheck) {
+        if self.0.is_ok() {
+            self.0 = other.0;
+        }
+    }
+}
+
+impl Default for CausalCheck {
+    fn default() -> CausalCheck {
+        CausalCheck(Ok(()))
     }
 }

--- a/src/sync/causal/cell.rs
+++ b/src/sync/causal/cell.rs
@@ -124,7 +124,7 @@ impl<T> CausalCell<T> {
         self.check2().unwrap()
     }
 
-    fn check2_mut(&self) -> Result<(), String> {
+    fn check2(&self) -> Result<(), String> {
         rt::execution(|execution| {
             let mut immut_access_version = self.immut_access_version.borrow_mut();
             let mut_access_version = self.mut_access_version.borrow();
@@ -165,7 +165,7 @@ impl<T> CausalCell<T> {
         self.check2_mut().unwrap();
     }
 
-    fn check2(&self) -> Result<(), String> {
+    fn check2_mut(&self) -> Result<(), String> {
         rt::execution(|execution| {
             let immut_access_version = self.immut_access_version.borrow();
             let mut mut_access_version = self.mut_access_version.borrow_mut();

--- a/src/sync/causal/mod.rs
+++ b/src/sync/causal/mod.rs
@@ -1,3 +1,3 @@
 mod cell;
 
-pub use self::cell::CausalCell;
+pub use self::cell::{CausalCell, CausalCheck};

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -8,7 +8,7 @@ mod mutex;
 mod notify;
 
 pub use self::arc::Arc;
-pub use self::causal::CausalCell;
+pub use self::causal::{CausalCell, CausalCheck};
 pub use self::condvar::{Condvar, WaitTimeoutResult};
 pub use self::mutex::{Mutex, MutexGuard};
 pub use self::notify::Notify;


### PR DESCRIPTION
`CausalCell` provides a structure that verifies that the accessing
thread has synchronized appropriately to be able to to access the cell.
However, there are algorithms where a thread must read
**optimistically** from a causal cell before it knows that it can
perform the read. In this case, the thread reads the bytes from the cell
to a temporary location then performs the necessary atomic operation to
verify access.

To model this, a new API is added to CausalCell that allows deferring
the causality check to a later time. `with_deferred` returns a
`CausalCheck` that can be used at a later time to assert the previous
access was correct.