### PR TITLE
fix AtomicWaker

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,6 +133,12 @@ macro_rules! debug {
     };
 }
 
+macro_rules! dbg {
+    ($($t:tt)*) => {
+        $($t)*
+    };
+}
+
 pub mod model;
 mod rt;
 pub mod sync;

--- a/src/rt/mutex.rs
+++ b/src/rt/mutex.rs
@@ -96,7 +96,7 @@ impl Mutex {
             // Set the lock to the current thread
             state.lock = Some(thread_id);
 
-            state.synchronize.sync_load(&mut execution.threads, Acquire);
+            dbg!(state.synchronize.sync_load(&mut execution.threads, Acquire));
 
             if state.seq_cst {
                 // Establish sequential consistency between locks


### PR DESCRIPTION
Add a `yield_now` when `register` wakes the given task due to the state
being locked. This behavior results in a spin lock, so it must be
annotated as such.