### PR TITLE
add Send + Sync impls for Mutex

### DIFF
--- a/src/sync/mutex.rs
+++ b/src/sync/mutex.rs
@@ -74,3 +74,6 @@ impl<'a, T: 'a> Drop for MutexGuard<'a, T> {
         self.lock.object.release_lock();
     }
 }
+
+unsafe impl<T: Send> Send for Mutex<T> {}
+unsafe impl<T: Send> Sync for Mutex<T> {}


### PR DESCRIPTION
Since `loom`'s Mutex contains a `RefCell`, it does not implement `Sync`.
This prevents it from being used in most contexts where the standard
library's `Mutex` type is used.

This branch adds `Send` and `Sync` impls for `loom`'s `Mutex`, with the
same bounds as `std::sync::Mutex`. It's worth noting that these impls
are only safe in the context of a loom test.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>