### PR TITLE
Prepare v0.2.8 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.2.8 (September 30, 2019)
+
+### Chore
+- Update futures-util dependency version (#70).
+
 # 0.2.7 (September 26, 2019)
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,12 @@ name = "loom"
 #   - Cargo.toml
 #   - README.md
 # - Create git tag
-version = "0.2.7"
+version = "0.2.8"
 edition = "2018"
 license = "MIT"
 authors = ["Carl Lerche <me@carllerche.com>"]
 description = "Permutation testing for concurrent code"
-documentation = "https://docs.rs/loom/0.2.7/loom"
+documentation = "https://docs.rs/loom/0.2.8/loom"
 homepage = "https://github.com/carllerche/loom"
 repository = "https://github.com/carllerche/loom"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To use `loom`, first add this to your `Cargo.toml`:
 
 ```toml
 [dev-dependencies]
-loom = "0.2.7"
+loom = "0.2.8"
 ```
 
 Next, create a test file and add a test:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/loom/0.2.7")]
+#![doc(html_root_url = "https://docs.rs/loom/0.2.8")]
 #![deny(missing_debug_implementations, missing_docs, rust_2018_idioms)]
 #![cfg_attr(test, deny(warnings))]
 


### PR DESCRIPTION
Unblock https://github.com/tokio-rs/tokio/pull/1610

This may cause a version conflict in crates that currently depend on tokio-0.2.0-alpha. This is because [loom pins version of futures-util-preview](https://github.com/carllerche/loom/blob/e352ded9887ab0bcc9f868b08ec3bab12b81216e/Cargo.toml#L40) and [tokio does not pin version of loom](https://github.com/tokio-rs/tokio/blob/7c341f45e03c26187b7146c5a10f404de86cca9c/tokio-sync/Cargo.toml#L36). (This may also have happened in previous releases.)

However, both futures-preview and tokio are pre-releases and loom's futures support is an optional feature... and [optional features do not necessarily have the same stability as crate itself.](https://github.com/rust-lang/rfcs/blob/master/text/1105-api-evolution.md#major-change-going-from-stable-to-nightly)

r? @carllerche 