### PR TITLE
Misc fixes

### DIFF
--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -139,9 +139,14 @@ where
 }
 
 pub fn thread_done() {
+    let locals = execution(|execution| execution.threads.active_mut().drop_locals());
+
+    // Drop outside of the execution context
+    drop(locals);
+
     execution(|execution| {
-        execution.threads.active_mut().set_terminated();
         execution.threads.active_mut().operation = None;
-        execution.schedule()
+        execution.threads.active_mut().set_terminated();
+        execution.schedule();
     });
 }

--- a/src/sync/arc.rs
+++ b/src/sync/arc.rs
@@ -33,6 +33,17 @@ impl<T> Arc<T> {
         // this.inner.ref_cnt.load(SeqCst)
     }
 
+    /// Returns a mutable reference to the inner value, if there are
+    /// no other `Arc` or [`Weak`][weak] pointers to the same value.
+    pub fn get_mut(this: &mut Self) -> Option<&mut T> {
+        if this.inner.obj.get_mut() {
+            assert_eq!(1, std::sync::Arc::strong_count(&this.inner));
+            Some(&mut std::sync::Arc::get_mut(&mut this.inner).unwrap().value)
+        } else {
+            None
+        }
+    }
+
     /// Returns `true` if the two `Arc`s point to the same value (not
     /// just values that compare as equal).
     pub fn ptr_eq(this: &Self, other: &Self) -> bool {


### PR DESCRIPTION
Collecting up a bunch of fixes.

This includes a fix to the thread local implementation. All "hooks" must be called from outside of the `rt::execution` closure.