### PR TITLE
Add `loom::sync::Mutex::try_lock`

### DIFF
--- a/src/rt/mutex.rs
+++ b/src/rt/mutex.rs
@@ -43,7 +43,6 @@ impl Mutex {
         assert!(self.post_acquire(), "expected to be able to acquire lock");
     }
 
-    #[cfg(feature = "futures")]
     pub(crate) fn try_acquire_lock(&self) -> bool {
         self.obj.branch_opaque();
         self.post_acquire()


### PR DESCRIPTION
## Motivation

Loom's `Mutex` lacks a `try_lock` method like `std::sync::Mutex` has. In
order to simulate all code that uses `std`'s mutex, we should add this.

## Solution:

This branch adds `try_lock` to `loom::sync::Mutex`. This was easy to
implement using the existing `try_acquire_lock` on `rt::Mutex`, which is
no longer feature flagged with the "futures" feature.

Closes #82

Signed-off-by: Eliza Weisman <eliza@buoyant.io>